### PR TITLE
fix issue #6

### DIFF
--- a/scripts/simulate.js
+++ b/scripts/simulate.js
@@ -13,9 +13,9 @@
 
             axios.get(URL_API_SIMULATOR, {
                 params: {
-                    investedAmount: investedAmount.replace(/\./g, '').replace('R$', '').trim(),
+                    investedAmount: investedAmount.replace(/\./g, '').replace(/\,/g, '.').replace('R$', '').trim(),
                     index: 'CDI',
-                    rate: rate.replace(/\./g, '').replace('%', '').trim(),
+                    rate: rate.replace(/\,/g, '.').replace('%', '').trim(),
                     isTaxFree: false,
                     maturityDate:  parseDate(maturityDate)
                 }


### PR DESCRIPTION
Simulação descrita na issue #6.

No valor investido foi trocado o ponto por vazio, e depois, a vírgula para ponto. Por exemplo: R$ 1.000,50.
```javascript
investedAmount: investedAmount.replace(/\./g, '').replace(/\,/g, '.').replace('R$', '').trim(),
```

Na taxa do CDI foi trocado a vírgula por ponto. Por exemplo: 105,00 ou 94,50.
```javascript
rate: rate.replace(/\,/g, '.').replace('%', '').trim(),
```

