### PR TITLE
Remove coveralls após after_success

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
 language: node_js
 node_js:
    - '8.8.1'
-after_success:
-  - coveralls


### PR DESCRIPTION
O travis-ci esta demorando muito pra finalizar o build, optaremos por disparar o coveralls por linha de comando.